### PR TITLE
update the reference link: better in v2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,9 +10,7 @@ filters to demonstrate how they work.
 
 ## context
 
-More info here:
-
-http://git-scm.com/book/ch7-2.html
+[More info here](http://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Keyword-Expansion)
 
 ## how it works
 


### PR DESCRIPTION
I changed your 'More info here' link to point to more ontopic content in the v2 book:

```
http://git-scm.com/book/ch7-2.html (only discusses interactive staging)
http://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Keyword-Expansion
```
